### PR TITLE
Add Sections and improve Pymupdf handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi~=0.111.0
 llama-cloud-services~=0.6.1
 numpy~=1.24.3
 pandas==2.0.2
-parse-document-model==0.2.0
+parse-document-model==0.2.1
 pydantic
 pydantic_settings~=2.2.1
 python-magic; platform_system != "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi~=0.111.0
 llama-cloud-services~=0.6.1
 numpy~=1.24.3
 pandas==2.0.2
-parse-document-model==0.2.1
+parse-document-model==0.2.2
 pydantic
 pydantic_settings~=2.2.1
 python-magic; platform_system != "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pydantic
 pydantic_settings~=2.2.1
 python-magic; platform_system != "Windows"
 python-magic-bin; platform_system == "Windows"
-pymupdf~=1.24.3
+pymupdf==1.25.5
 requests==2.32.3
 unstructured-client~=0.29.0
 uvicorn==0.22.0

--- a/text_extractor/parser/pdfact_parser.py
+++ b/text_extractor/parser/pdfact_parser.py
@@ -30,6 +30,20 @@ class PdfactParser(PDFParser):
         return document
 
 
+def assign_sections(document: Document) -> Document:
+    current_heading = ["", "", "", ""]
+    for page in document.content:
+        for chunk in page.content:
+            if chunk.category == "heading":
+                level = chunk.attributes.level
+                if 1 <= level <= 4:
+                    current_heading[level - 1] = chunk.content
+                    for i in range(level, len(current_heading)):
+                        current_heading[i] = ""
+            chunk.attributes.section = " |>| ".join([heading for heading in current_heading if heading != ""])
+    return document
+
+
 def pdfact_to_document(json_data: dict) -> Document:
     colors = [Color(**color) for color in json_data.get('colors', [])]
     fonts = [Font(id=font['id'], name=font['name'], size=-1) for font in json_data.get('fonts', [])]

--- a/text_extractor/parser/pdfact_parser.py
+++ b/text_extractor/parser/pdfact_parser.py
@@ -27,6 +27,7 @@ class PdfactParser(PDFParser):
         res = heading_filter(res)
         document = pdfact_to_document(res)
         document = determine_heading_level(document)
+        document = assign_sections(document)
         return document
 
 
@@ -34,9 +35,9 @@ def assign_sections(document: Document) -> Document:
     current_heading = ["", "", "", ""]
     for page in document.content:
         for chunk in page.content:
-            if chunk.category == "heading":
+            if chunk.category == "heading" and len(chunk.content) <= 100:
                 level = chunk.attributes.level
-                if 1 <= level <= 4:
+                if level is not None and 1 <= level <= 4:
                     current_heading[level - 1] = chunk.content
                     for i in range(level, len(current_heading)):
                         current_heading[i] = ""
@@ -255,7 +256,7 @@ def determine_heading_level(document: Document) -> Document:
     :return: The document with updated heading levels assigned to each heading node.
     """
     heading_styles = []
-    largest_font_styles = []
+    single_occurrences_fonts = []
 
     for page in document.content:
         for node in page.content:
@@ -288,13 +289,12 @@ def determine_heading_level(document: Document) -> Document:
     # Sort the styles by font size in descending order
     heading_styles = sorted(heading_styles, key=lambda x: x['font_size'], reverse=True)
 
+    # Ignore headings that occur only once and headings that occur too many times
     for style in heading_styles:
         if style['occurrences'] == 1:
-            largest_font_styles.append(style)
-        else:
-            break
-
-    heading_styles = [style for style in heading_styles if style not in largest_font_styles]
+            single_occurrences_fonts.append(style)
+    heading_styles = [style for style in heading_styles
+                      if (style not in single_occurrences_fonts) and (style['occurrences'] < len(document.content))]
 
     assigned_levels = assign_heading_levels(heading_styles)
 
@@ -312,10 +312,10 @@ def determine_heading_level(document: Document) -> Document:
 
                 if font_name and font_size:
                     if any(style['font_name'] == font_name and style['font_size'] == font_size for style in
-                           largest_font_styles):
+                           single_occurrences_fonts):
                         node.category = "title"
                     else:
-                        level = 4
+                        level = None
                         for style in assigned_levels:
                             if style['font_name'] == font_name and style['font_size'] == font_size:
                                 level = style['level']

--- a/text_extractor/parser/pymupdf_parser.py
+++ b/text_extractor/parser/pymupdf_parser.py
@@ -1,40 +1,68 @@
-from typing import List
+from typing import Literal
 
-import fitz
+import pymupdf
 from parse_document_model import Document, Page
-from parse_document_model.attributes import PageAttributes
+from parse_document_model.attributes import BoundingBox, TextAttributes
 from parse_document_model.document import Text
+from parse_document_model.marks import Font, TextStyleMark, Color
 
-from text_extractor.models import Chunk
-from text_extractor.parser.pdf_parser import PDFParser, clean_text
+from text_extractor.parser.pdf_parser import PDFParser
 
 
 class PymupdfParser(PDFParser):
     def parse(self, filename: str, **kwargs) -> Document:
-        pdf = fitz.open(filename)
-        documents = []
-        for page in pdf:
-            text = page.get_text()
-            text = clean_text(text)
-            documents.append(Chunk(text, {"page_number": page.number + 1}))
-        return chunks_to_document(documents)
+        pdf = pymupdf.open(filename)
+        page_list = []
+        for i, page in enumerate(pdf):
+            page_nodes = []
+            for block in page.get_text("dict")["blocks"]:
+                if block["type"] == 0:
+                    text = span_to_texts(block, page=i + 1)
+                    page_nodes.extend(text)
+            page_list.append(Page(content=page_nodes))
+        return Document(content=page_list)
 
 
-def chunks_to_document(doc_parsed: List[Chunk]) -> Document:
-    pages = []
-    for page in doc_parsed:
-        page_number = page.metadata['page_number']
-        attributes = PageAttributes(page=page_number)
-        content = [Text(content=page.text, category="body")]
+def span_to_texts(block: dict, page: int) -> list[Text]:
+    res = []
+    text_marks = set()
+    bboxes = []
+    content = ""
+    for line in block["lines"]:
+        for span in line["spans"]:
+            font = Font(id=span["font"], name=span["font"], size=int(span["size"]))
+            color = hex_to_rgb(span["color"])
+            text_marks.add(TextStyleMark(category="textStyle",
+                                         font=font,
+                                         color=Color(id=hex(span["color"]),
+                                                     r=color[0], g=color[1], b=color[2])))
+            # font_type_mark = Mark(category=flag_to_mark(span["flags"]))
+            bboxes.append(BoundingBox(min_x=span["bbox"][0],
+                                      min_y=span["bbox"][1],
+                                      max_x=span["bbox"][2],
+                                      max_y=span["bbox"][3],
+                                      page=page))
+            content += span["text"]
+        content += " "
 
-        page = Page(
-            attributes=attributes,
-            content=content
-        )
+    if len(content.strip()) == 0:
+        return res
 
-        pages.append(page)
+    text = Text(content=content,
+                category="body",
+                attributes=TextAttributes(bounding_box=bboxes),
+                marks=list(text_marks))
+    res.append(text)
+    return res
 
-    document = Document(
-        content=pages,
-    )
-    return document
+
+def flag_to_mark(flag: int) -> Literal["superscripted", "italic", "serifed", "monospaced", "bold"]:
+    # TODO: Implement this
+    pass
+
+
+def hex_to_rgb(hex_color: int) -> tuple[int, int, int]:
+    r = (hex_color >> 16) & 0xFF
+    g = (hex_color >> 8) & 0xFF
+    b = hex_color & 0xFF
+    return r, g, b

--- a/text_extractor/parser/pymupdf_parser.py
+++ b/text_extractor/parser/pymupdf_parser.py
@@ -57,7 +57,6 @@ def span_to_texts(block: dict, page: int) -> list[Text]:
 
 
 def flag_to_mark(flag: int) -> Literal["superscripted", "italic", "serifed", "monospaced", "bold"]:
-    # TODO: Implement this
     pass
 
 


### PR DESCRIPTION
This PR adds the section attribute for the text nodes, using `pdfact` as driver. The section is composed by the entire heading hierarchy; the attribute is a string with different headings level separated by `|>|`.

In addition, the `pymupdf` driver now returns all the text attributes. 

This PR requires `parse-document-model>=0.2.1` due to the addition of the section attribute.