### PR TITLE
Update LlamaParser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi~=0.111.0
-llama-cloud-services~=0.6.1
+llama-cloud-services~=0.6.21
 numpy~=1.24.3
 pandas==2.0.2
 parse-document-model==0.2.2


### PR DESCRIPTION
This PR updates the `llama-cloud-services` to the latest versione (0.6.21) and add the conversion from the `JobResult` given by LlamaCloud to the `Document` of parse-document-model library.