### PR TITLE
Improve batches

### DIFF
--- a/docs/tutorials/using_cli.md
+++ b/docs/tutorials/using_cli.md
@@ -26,13 +26,13 @@ The `parse` command is a powerful tool for extracting text from documents with e
 
 ### Basic Usage
 
-Parse a single document using the default settings (PyMuPDF driver, markdown output):
+Parse a single document using the default settings (PyMuPDF driver, json output):
 
 ```bash
 parxy parse document.pdf
 ```
 
-This creates a `document.md` file in the same directory as the source file.
+This creates a `pymupdf-document.json` file in the same directory as the source file. Parxy always prefix the output file with the driver name.
 
 ### Processing Multiple Files and Folders
 
@@ -103,29 +103,19 @@ Specify a driver with the `--driver` (`-d`) option:
 
 ```bash
 parxy parse --driver llamaparse document.pdf
+# output will be saved as llamaparse-document.json
 ```
 
 ### Using Multiple Drivers for Comparison
 
-Parse the same document(s) with multiple drivers by specifying `--driver` multiple times:
+Parse the same document(s) with multiple drivers by specifying `--driver` (or `-d` for short) multiple times:
 
 ```bash
 parxy parse document.pdf -d pymupdf -d llamaparse
 ```
 
-When using multiple drivers, Parxy automatically appends the driver name to the output filenames:
-- `document_pymupdf.md`
-- `document_llamaparse.md`
+When using multiple drivers, Parxy always prepend the driver name to the output filenames, e.g. `pymupdf-document.json`, `llamaparse-document.json`. This is particularly useful for comparing extraction quality across different parsers.
 
-This is particularly useful for comparing extraction quality across different parsers.
-
-### Showing Output in Console
-
-By default, output is only saved to files. To also display content in the console, use the `--show` (`-s`) flag:
-
-```bash
-parxy parse document.pdf --show
-```
 
 ### Progress Tracking
 

--- a/src/parxy_cli/commands/parse.py
+++ b/src/parxy_cli/commands/parse.py
@@ -133,7 +133,7 @@ def save_batch_result(
     mode: OutputMode,
     output_dir: Optional[Path],
     show: bool,
-    use_driver_suffix: bool = False,
+    use_driver_prefix: bool = True,
 ) -> tuple[str, int]:
     """
     Save a BatchResult to file.
@@ -143,7 +143,7 @@ def save_batch_result(
         mode: Output mode
         output_dir: Optional output directory
         show: Whether to show content in console
-        use_driver_suffix: Whether to append driver name to output filename
+        use_driver_prefix: Whether to prepend driver name to output filename
 
     Returns:
         Tuple of (output_path, page_count)
@@ -164,8 +164,8 @@ def save_batch_result(
         base_name = file_path.stem
 
     # If multiple drivers, append driver name to filename
-    if use_driver_suffix and result.driver:
-        base_name = f'{base_name}-{result.driver}'
+    if use_driver_prefix and result.driver:
+        base_name = f'{result.driver}-{base_name}'
 
     extension = get_output_extension(mode)
     output_path = output_dir / f'{base_name}{extension}'
@@ -312,14 +312,6 @@ def parse(
     # Calculate total tasks
     total_tasks = len(files) * len(drivers)
 
-    # Determine if we should use driver suffix (when multiple drivers are used)
-    use_driver_suffix = len(drivers) > 1
-
-    if use_driver_suffix:
-        console.info(
-            'You have specified more than one driver. Driver name will be added as suffix to the file name while saving.'
-        )
-
     error_count = 0
 
     # Show info
@@ -350,7 +342,6 @@ def parse(
                         mode=mode,
                         output_dir=output_path,
                         show=show,
-                        use_driver_suffix=use_driver_suffix,
                     )
                     console.print(
                         f'[faint]⎿ [/faint] {file_name} via {result.driver} to [success]{output_file}[/success] [faint]({page_count} pages)[/faint]'

--- a/src/parxy_core/facade/circuit_breaker.py
+++ b/src/parxy_core/facade/circuit_breaker.py
@@ -1,0 +1,54 @@
+"""Circuit breaker for batch processing to short-circuit systemic driver failures."""
+
+import threading
+
+from parxy_core.exceptions import (
+    AuthenticationException,
+    QuotaExceededException,
+    RateLimitException,
+)
+
+IMMEDIATE_TRIP_EXCEPTIONS = (
+    AuthenticationException,
+    QuotaExceededException,
+    RateLimitException,
+)
+
+
+class CircuitBreakerState:
+    """Per-batch circuit breaker that tracks driver-level failures.
+
+    When a driver raises an exception that indicates a systemic problem
+    (bad credentials, exhausted quota, rate limit), the circuit opens for
+    that driver and all subsequent tasks targeting it are short-circuited
+    with the original tripping exception.
+
+    Thread-safe: guards internal state with a lock so concurrent workers
+    in ``ThreadPoolExecutor`` can safely read and write.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._open_drivers: dict[str, Exception] = {}
+
+    def is_open(self, driver_name: str) -> bool:
+        """Return True if the circuit is open (tripped) for *driver_name*."""
+        with self._lock:
+            return driver_name in self._open_drivers
+
+    def get_trip_exception(self, driver_name: str) -> Exception | None:
+        """Return the exception that tripped the circuit, or None."""
+        with self._lock:
+            return self._open_drivers.get(driver_name)
+
+    def record_failure(self, driver_name: str, exception: Exception) -> None:
+        """Record a failure and trip the circuit if the exception warrants it.
+
+        Only exceptions listed in ``IMMEDIATE_TRIP_EXCEPTIONS`` cause the
+        circuit to open.  Per-file errors (e.g. ``FileNotFoundException``)
+        are ignored.
+        """
+        if isinstance(exception, IMMEDIATE_TRIP_EXCEPTIONS):
+            with self._lock:
+                if driver_name not in self._open_drivers:
+                    self._open_drivers[driver_name] = exception

--- a/src/parxy_core/facade/parxy.py
+++ b/src/parxy_core/facade/parxy.py
@@ -239,7 +239,11 @@ class Parxy:
                 )
             except Exception as e:
                 return BatchResult(
-                    file=file, driver=driver_name, document=None, error=str(e)
+                    file=file,
+                    driver=driver_name,
+                    document=None,
+                    error=str(e),
+                    exception=e,
                 )
 
         with ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/src/parxy_core/models/models.py
+++ b/src/parxy_core/models/models.py
@@ -266,12 +266,15 @@ class BatchResult:
         The parsed document, or None if an error occurred
     error : str | None
         Error message if parsing failed, None otherwise
+    exception : Exception | None
+        The original exception if parsing failed, None otherwise
     """
 
     file: Union[str, BytesIO, bytes]
     driver: str
     document: Optional['Document']
     error: Optional[str]
+    exception: Optional[Exception] = None
 
     @property
     def success(self) -> bool:

--- a/tests/commands/test_parse.py
+++ b/tests/commands/test_parse.py
@@ -125,7 +125,7 @@ def test_parse_command_with_output_directory(runner, mock_document, tmp_path):
         assert result.exit_code == 0
 
         # Verify the output file was created (default mode is JSON)
-        output_file = output_dir / 'test.json'
+        output_file = output_dir / 'pymupdf-test.json'
         assert output_file.exists()
 
 
@@ -160,7 +160,7 @@ def test_parse_command_with_markdown_output(runner, mock_document, tmp_path):
         assert result.exit_code == 0
 
         # Verify the output file was created with .md extension
-        output_file = output_dir / 'test.md'
+        output_file = output_dir / 'pymupdf-test.md'
         assert output_file.exists()
 
 
@@ -234,9 +234,9 @@ def test_parse_command_with_multiple_drivers(runner, mock_document, tmp_path):
 
         assert result.exit_code == 0
 
-        # Verify that files with driver suffixes were created
-        assert (output_dir / 'test-pymupdf.json').exists()
-        assert (output_dir / 'test-llamaparse.json').exists()
+        # Verify that files with driver prefixes were created
+        assert (output_dir / 'pymupdf-test.json').exists()
+        assert (output_dir / 'llamaparse-test.json').exists()
 
 
 def test_collect_files_non_recursive(tmp_path):

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -172,9 +172,7 @@ class TestBatchCircuitBreaker:
 
     @patch.object(Parxy, 'parse')
     def test_per_driver_isolation(self, mock_parse):
-        auth_exc = AuthenticationException(
-            'Invalid API key', service='llamaparse'
-        )
+        auth_exc = AuthenticationException('Invalid API key', service='llamaparse')
 
         def parse_side_effect(file, level, driver_name):
             if driver_name == 'llamaparse':

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,225 @@
+from unittest.mock import patch
+
+from parxy_core.exceptions import (
+    AuthenticationException,
+    FileNotFoundException,
+    ParsingException,
+    QuotaExceededException,
+    RateLimitException,
+)
+from parxy_core.facade.circuit_breaker import CircuitBreakerState
+from parxy_core.facade import Parxy
+from parxy_core.models import Document, Page
+
+
+class TestCircuitBreakerState:
+    def test_circuit_initially_closed(self):
+        breaker = CircuitBreakerState()
+
+        assert breaker.is_open('llamaparse') is False
+        assert breaker.get_trip_exception('llamaparse') is None
+
+    def test_authentication_exception_trips_circuit(self):
+        breaker = CircuitBreakerState()
+        exc = AuthenticationException('Invalid API key', service='llamaparse')
+
+        breaker.record_failure('llamaparse', exc)
+
+        assert breaker.is_open('llamaparse') is True
+        assert breaker.get_trip_exception('llamaparse') is exc
+
+    def test_quota_exceeded_exception_trips_circuit(self):
+        breaker = CircuitBreakerState()
+        exc = QuotaExceededException('Quota exhausted', service='llamaparse')
+
+        breaker.record_failure('llamaparse', exc)
+
+        assert breaker.is_open('llamaparse') is True
+        assert breaker.get_trip_exception('llamaparse') is exc
+
+    def test_rate_limit_exception_trips_circuit(self):
+        breaker = CircuitBreakerState()
+        exc = RateLimitException('Rate limit exceeded', service='llamaparse')
+
+        breaker.record_failure('llamaparse', exc)
+
+        assert breaker.is_open('llamaparse') is True
+        assert breaker.get_trip_exception('llamaparse') is exc
+
+    def test_file_not_found_does_not_trip(self):
+        breaker = CircuitBreakerState()
+        exc = FileNotFoundException('File missing', service='llamaparse')
+
+        breaker.record_failure('llamaparse', exc)
+
+        assert breaker.is_open('llamaparse') is False
+
+    def test_parsing_exception_does_not_trip(self):
+        breaker = CircuitBreakerState()
+        exc = ParsingException('Parse error', service='llamaparse')
+
+        breaker.record_failure('llamaparse', exc)
+
+        assert breaker.is_open('llamaparse') is False
+
+    def test_generic_exception_does_not_trip(self):
+        breaker = CircuitBreakerState()
+        exc = Exception('Something went wrong')
+
+        breaker.record_failure('llamaparse', exc)
+
+        assert breaker.is_open('llamaparse') is False
+
+    def test_trip_is_per_driver(self):
+        breaker = CircuitBreakerState()
+        exc = AuthenticationException('Invalid API key', service='llamaparse')
+
+        breaker.record_failure('llamaparse', exc)
+
+        assert breaker.is_open('llamaparse') is True
+        assert breaker.is_open('pdfact') is False
+
+    def test_original_exception_preserved(self):
+        breaker = CircuitBreakerState()
+        exc = AuthenticationException('Invalid API key', service='llamaparse')
+
+        breaker.record_failure('llamaparse', exc)
+
+        retrieved = breaker.get_trip_exception('llamaparse')
+        assert retrieved is exc
+        assert isinstance(retrieved, AuthenticationException)
+
+    def test_first_trip_exception_preserved(self):
+        breaker = CircuitBreakerState()
+        first = AuthenticationException('First error', service='llamaparse')
+        second = RateLimitException('Second error', service='llamaparse')
+
+        breaker.record_failure('llamaparse', first)
+        breaker.record_failure('llamaparse', second)
+
+        assert breaker.get_trip_exception('llamaparse') is first
+
+
+class TestBatchCircuitBreaker:
+    @patch.object(Parxy, 'parse')
+    def test_auth_failure_short_circuits_remaining_tasks(self, mock_parse):
+        exc = AuthenticationException('Invalid API key', service='pymupdf')
+        mock_parse.side_effect = exc
+
+        results = Parxy.batch(
+            tasks=['doc1.pdf', 'doc2.pdf', 'doc3.pdf'],
+            workers=1,
+        )
+
+        assert len(results) == 3
+        assert all(r.failed for r in results)
+        # Only the first call should actually reach parse
+        assert mock_parse.call_count == 1
+        # All results carry the tripping exception
+        for r in results:
+            assert r.exception is exc
+
+    @patch.object(Parxy, 'parse')
+    def test_quota_failure_short_circuits_remaining_tasks(self, mock_parse):
+        exc = QuotaExceededException('Quota exhausted', service='pymupdf')
+        mock_parse.side_effect = exc
+
+        results = Parxy.batch(
+            tasks=['doc1.pdf', 'doc2.pdf'],
+            workers=1,
+        )
+
+        assert len(results) == 2
+        assert mock_parse.call_count == 1
+        assert all(r.exception is exc for r in results)
+
+    @patch.object(Parxy, 'parse')
+    def test_rate_limit_failure_short_circuits_remaining_tasks(self, mock_parse):
+        exc = RateLimitException('Rate limit exceeded', service='pymupdf')
+        mock_parse.side_effect = exc
+
+        results = Parxy.batch(
+            tasks=['doc1.pdf', 'doc2.pdf'],
+            workers=1,
+        )
+
+        assert len(results) == 2
+        assert mock_parse.call_count == 1
+        assert all(r.exception is exc for r in results)
+
+    @patch.object(Parxy, 'parse')
+    def test_file_not_found_does_not_short_circuit(self, mock_parse):
+        call_count = 0
+
+        def parse_side_effect(file, level, driver_name):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise FileNotFoundException('File missing', service='pymupdf')
+            return Document(pages=[Page(number=1, text='test')])
+
+        mock_parse.side_effect = parse_side_effect
+
+        results = Parxy.batch(
+            tasks=['missing.pdf', 'doc2.pdf', 'doc3.pdf'],
+            workers=1,
+        )
+
+        assert len(results) == 3
+        assert mock_parse.call_count == 3
+        assert sum(1 for r in results if r.failed) == 1
+        assert sum(1 for r in results if r.success) == 2
+
+    @patch.object(Parxy, 'parse')
+    def test_per_driver_isolation(self, mock_parse):
+        auth_exc = AuthenticationException(
+            'Invalid API key', service='llamaparse'
+        )
+
+        def parse_side_effect(file, level, driver_name):
+            if driver_name == 'llamaparse':
+                raise auth_exc
+            return Document(pages=[Page(number=1, text='test')])
+
+        mock_parse.side_effect = parse_side_effect
+
+        results = Parxy.batch(
+            tasks=['doc1.pdf', 'doc2.pdf'],
+            drivers=['llamaparse', 'pymupdf'],
+            workers=1,
+        )
+
+        # 2 files x 2 drivers = 4 results
+        assert len(results) == 4
+
+        llama_results = [r for r in results if r.driver == 'llamaparse']
+        pymupdf_results = [r for r in results if r.driver == 'pymupdf']
+
+        # All llamaparse results should fail
+        assert all(r.failed for r in llama_results)
+        # Only 1 actual parse call for llamaparse (second is short-circuited)
+        assert all(r.exception is auth_exc for r in llama_results)
+
+        # All pymupdf results should succeed
+        assert all(r.success for r in pymupdf_results)
+
+    @patch.object(Parxy, 'parse')
+    def test_short_circuited_result_has_correct_fields(self, mock_parse):
+        exc = AuthenticationException('Bad key', service='llamaparse')
+        mock_parse.side_effect = exc
+
+        results = Parxy.batch(
+            tasks=['doc1.pdf', 'doc2.pdf'],
+            drivers=['llamaparse'],
+            workers=1,
+        )
+
+        # Second result is the short-circuited one
+        short_circuited = results[1]
+        assert short_circuited.file == 'doc2.pdf'
+        assert short_circuited.driver == 'llamaparse'
+        assert short_circuited.document is None
+        assert short_circuited.error == str(exc)
+        assert short_circuited.exception is exc
+        assert short_circuited.failed is True
+        assert short_circuited.success is False

--- a/tests/test_parxy_facade.py
+++ b/tests/test_parxy_facade.py
@@ -76,6 +76,28 @@ class TestBatchResult:
 
         assert result.failed is False
 
+    def test_exception_preserved_on_failure(self):
+        exc = ValueError('Invalid format')
+        result = BatchResult(
+            file='test.pdf',
+            driver='pymupdf',
+            document=None,
+            error=str(exc),
+            exception=exc,
+        )
+
+        assert result.exception is exc
+        assert isinstance(result.exception, ValueError)
+        assert str(result.exception) == 'Invalid format'
+
+    def test_exception_defaults_to_none(self):
+        doc = Document(pages=[Page(number=1, text='test')])
+        result = BatchResult(
+            file='test.pdf', driver='pymupdf', document=doc, error=None
+        )
+
+        assert result.exception is None
+
 
 class TestBatchTask:
     def test_batch_task_with_file_only(self):


### PR DESCRIPTION
- Add circuit breaker for authentication and quota exceptions to batch and batch_iter
- `parse` command use batch by default
- Remove `--parallel` from `parse` command, processing uses the batch mode so it is always parallel
- Include full exception in BatchResult in case of failure
- `parse` output files with driver prefix always, e.g. input document.pdf -> pymupdf-document.pdf